### PR TITLE
Update for Arduino 1.0+

### DIFF
--- a/Mirf/Mirf.h
+++ b/Mirf/Mirf.h
@@ -27,7 +27,7 @@
 #ifndef _MIRF_H_
 #define _MIRF_H_
 
-#include <WProgram.h>
+#include <Arduino.h>
 
 #include "nRF24L01.h"
 #include "MirfSpiDriver.h"


### PR DESCRIPTION
Simple one-line update to change the WProgram.h include statement to the latest Arduino.h include statement instead, for compatibility with the latest version of Arduino.
