### PR TITLE
reset bug

### DIFF
--- a/Mirf/Mirf.cpp
+++ b/Mirf/Mirf.cpp
@@ -89,6 +89,7 @@ void Nrf24l::init()
     csnHi();
 
     // Initialize spi module
+    spi = new MirfSpiDriver();
     spi->begin();
 
 }


### PR DESCRIPTION
The Mirf.init function resets the nano board when called.
This fixes the issue.
